### PR TITLE
fixed:画像単体の削除機能修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: %i[ show edit update destroy ]
+  before_action :set_user, only: %i[ show edit update destroy image_delete ]
 
   # GET /users or /users.json
   def index
@@ -22,7 +22,6 @@ class UsersController < ApplicationController
   # POST /users or /users.json
   def create
     @user = User.new(user_params)
-
     respond_to do |format|
       if @user.save
         format.html { redirect_to @user, notice: "User was successfully created." }
@@ -38,12 +37,23 @@ class UsersController < ApplicationController
   def update
     respond_to do |format|
       if @user.update(user_params)
+        # ストレージにあるアップロードした画像を消す
+        # @user.remove_avatar! if params[:user][:remove_avatar] == "1"
         format.html { redirect_to @user, notice: "User was successfully updated." }
         format.json { render :show, status: :ok, location: @user }
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
+    end
+  end
+
+  def image_delete
+    @user.remove_avatar!
+    if @user.save
+      redirect_to edit_user_path(@user), notice: "User was successfully image delete."
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -24,16 +24,11 @@
   <div class="my-5">
     <%= form.label :avatar %>
     <%= image_tag(user.avatar_url, class: "text-gray-700 underline hover:no-underline", width: "300", height:"200") if user.avatar? %>
+    <% if user.errors.none? && user.avatar? %>
+      <%= link_to '画像を削除する', image_delete_user_path(user), data: { turbo_method: :delete, turbo_confirm: "画像を削除しますか？" }, class: "rounded-md px-3.5 py-2.5 bg-red-600 hover:bg-red-500 text-white inline-block font-medium cursor-pointer" %>
+    <% end %>
     <%= form.file_field :avatar, class: ["block shadow-sm rounded-md border px-3 py-2 mt-2 w-full", {"border-gray-400 focus:outline-blue-600": user.errors[:avatar].none?, "border-red-400 focus:outline-red-600": user.errors[:avatar].any?}] %>
     <%= form.hidden_field :avatar_cache %>
-    <% if user.avatar? %>
-      <div>
-        <label>
-          <%= form.check_box :remove_avatar %>
-          Remove avatar
-        </label>
-      </div>
-    <% end %>
   </div>
 
   <div class="inline">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
-  resources :users
+  resources :users do
+    member do
+      delete :image_delete
+    end
+  end
   root "users#index"
 end


### PR DESCRIPTION
## 概要
- 画像単体の削除処理時にストレージに画像データが残っている現象を修正した。
- 画像単体の削除処理をチェックボックスとして他のデータと共にフォームデータとして送信していたが、ボタンクリックで画像データ単体の削除処理に変更した。